### PR TITLE
fix: change mode to PR in workflow config

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -20,7 +20,7 @@ jobs:
       force: ${{ github.event.inputs.force }}
       languages: |
         - go
-      mode: direct
+      mode: pr
       openapi_doc_auth_header: Authorization
       openapi_docs: |
         - https://raw.githubusercontent.com/smartcar/api-schema/master/speakeasy/openapi.yaml


### PR DESCRIPTION
This should allow us to update the SDK with a PR ahead of release day and only release when we're ready keeping our branch protections in place.

- https://app.asana.com/0/0/1205699302620050/f
- https://www.speakeasyapi.dev/docs/workflow-reference#pr-mode
![image](https://github.com/smartcar/go-sdk-v2/assets/10519686/cadee27b-2bf7-44e8-b791-2b57020a0666)
