### PR TITLE
chore: speakeasy migrate

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,31 +1,26 @@
 name: Generate
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
 "on":
-  workflow_dispatch:
-    inputs:
-      force:
-        description: Force generation of SDKs
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force generation of SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      force: ${{ github.event.inputs.force }}
-      languages: |
-        - go
-      mode: pr
-      openapi_doc_auth_header: Authorization
-      openapi_docs: |
-        - https://raw.githubusercontent.com/smartcar/api-schema/master/speakeasy/openapi.yaml
-      speakeasy_version: latest
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      openapi_doc_auth_token: ${{ secrets.OPENAPI_DOC_AUTH_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: pr
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            openapi_doc_auth_token: ${{ secrets.OPENAPI_DOC_AUTH_TOKEN }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,11 @@
+workflowVersion: 1.0.0
+sources:
+    my-source:
+        inputs:
+            - location: https://raw.githubusercontent.com/smartcar/api-schema/master/speakeasy/openapi.yaml
+              authHeader: Authorization
+              authSecret: $openapi_doc_auth_token
+targets:
+    smartcar:
+        target: go
+        source: my-source


### PR DESCRIPTION
This PR migrates this SDK to Speakeasy's new workflow file specification https://www.speakeasyapi.dev/docs/workflow-migration. `speakeasy migrate` was run to create this PR.

Example run output: 

![CleanShot 2024-05-07 at 14 19 53@2x](https://github.com/smartcar/go-sdk-v2/assets/108416695/d0046559-d074-472d-b270-f52dd02e9a77)

Benefits:

The complete generation workflow is emulated locally now by checking out repo and running `speakeasy run`
Opens up integrations with doc providers and other newer features. No code changes to SDK.